### PR TITLE
Improve behavior of `utils::defaultdict_to_dict`

### DIFF
--- a/mixtera/utils/utils.py
+++ b/mixtera/utils/utils.py
@@ -43,7 +43,7 @@ def merge_defaultdicts(d1: defaultdict, d2: defaultdict) -> defaultdict:
 
 
 def defaultdict_to_dict(ddict: Union[dict, defaultdict]) -> dict[Any, Any]:
-    if isinstance(ddict, defaultdict):
+    if isinstance(ddict, (defaultdict, dict)):
         ddict = {k: defaultdict_to_dict(v) for k, v in ddict.items()}
     return ddict
 


### PR DESCRIPTION
Current implementation of `defaultdict_to_dict` only calls recursively on `defaultdict` entries, but there might potentially be cases where a `defaultdict` is hidden within a normal `dict`. This change simply checks for the `dict` type as well.  