### PR TITLE
Removed the use of the legacy IndexType

### DIFF
--- a/mixtera/core/datacollection/__init__.py
+++ b/mixtera/core/datacollection/__init__.py
@@ -2,17 +2,8 @@
 This submodule contains Mixtera's datasets, which are the main API of Mixtera
 """
 
-from collections import defaultdict
-from typing import Union
-
-IndexType = defaultdict[str, defaultdict[str, defaultdict[int, dict[int, list[tuple[int, int]]]]]]
-UncompressedIndexType = defaultdict[
-    str, defaultdict[str, defaultdict[int, dict[int, list[Union[int, tuple[int, int]]]]]]
-]
-
-
 from .data_collection import MixteraDataCollection  # noqa: F401,E402 # pylint: disable=wrong-import-position
 from .property import Property  # noqa: F401,E402 # pylint: disable=wrong-import-position
 from .property_type import PropertyType  # noqa: F401,E402 # pylint: disable=wrong-import-position
 
-__all__ = ["MixteraDataCollection", "Property", "PropertyType", "IndexType", "UncompressedIndexType"]
+__all__ = ["MixteraDataCollection", "Property", "PropertyType"]

--- a/mixtera/core/datacollection/data_collection.py
+++ b/mixtera/core/datacollection/data_collection.py
@@ -3,10 +3,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, List, Optional, Type
 
 from mixtera.core.datacollection.datasets import Dataset
+from mixtera.core.datacollection.index import InMemoryDictionaryRangeIndex
 from mixtera.core.processing import ExecutionMode
 
 if TYPE_CHECKING:
-    from mixtera.core.datacollection import IndexType, PropertyType
+    from mixtera.core.datacollection import PropertyType
     from mixtera.core.datacollection.local import LocalDataCollection
     from mixtera.core.datacollection.remote import RemoteDataCollection
 
@@ -175,12 +176,16 @@ class MixteraDataCollection(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_index(self, property_name: Optional[str] = None) -> "IndexType":
+    def get_index(self, property_name: Optional[str] = None) -> Optional[InMemoryDictionaryRangeIndex]:
         """
         This function returns the index of the MixteraDataCollection.
 
         Args:
             property_name (Optional[str], optional): The name of the property to query.
                 If not provided, all properties are returned.
+
+        Returns:
+            An `InMemoryDictionaryRangeIndex` object or None if a `property_name`
+            is specified, but is not present in the index.
         """
         raise NotImplementedError()

--- a/mixtera/core/datacollection/datasets/crossaint_dataset.py
+++ b/mixtera/core/datacollection/datasets/crossaint_dataset.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Callable, Iterable
 
-from mixtera.core.datacollection import IndexType
 from mixtera.core.datacollection.datasets.dataset import Dataset
 from mixtera.core.datacollection.index.parser import MetadataParser
 
@@ -10,7 +9,7 @@ class CrossaintDataset(Dataset):
     type_id = 2
 
     @staticmethod
-    def build_file_index(loc: Path, metadata_parser: MetadataParser) -> IndexType:
+    def build_file_index(loc: Path, metadata_parser: MetadataParser) -> None:
         raise NotImplementedError("CrossaintDataset not yet supported.")
 
     @staticmethod

--- a/mixtera/core/datacollection/index/index_collection.py
+++ b/mixtera/core/datacollection/index/index_collection.py
@@ -4,8 +4,13 @@ from enum import Enum
 from typing import Union
 
 from loguru import logger
-from mixtera.core.datacollection import IndexType
-from mixtera.core.datacollection.index import Index, IndexDatasetEntryRangeType, IndexFeatureValueType, IndexRangeType
+from mixtera.core.datacollection.index import (
+    Index,
+    IndexDatasetEntryRangeType,
+    IndexFeatureValueType,
+    IndexRangeType,
+    IndexType,
+)
 from mixtera.utils import merge_dicts, ranges
 from mixtera.utils.utils import return_with_deepcopy_or_noop
 


### PR DESCRIPTION
Removed the use of the legacy `IndexType` and `UncompressedIndexType` formerly defined in `core/datacollection/__init__.py`. Also updated the returned type of `build_file_index` in `CroissantDataset` to `None` (such that it matches the `Dataset` interface), and the return type of `get_index` to `Optional[InMemoryDictionaryRangeIndex]` in the `MixteraDataCollection` such that it matches the current `LocalDataCollection` implementation. 