### PR TITLE
Use `mp.Lock` instead of `threading.Lock` to make examples run in `spawn` context

### DIFF
--- a/mixtera/core/client/local/local_stub.py
+++ b/mixtera/core/client/local/local_stub.py
@@ -1,4 +1,4 @@
-import threading
+import multiprocessing as mp
 from pathlib import Path
 from typing import Callable, Generator, Type
 
@@ -24,7 +24,7 @@ class LocalStub(MixteraClient):
             raise RuntimeError(f"Directory {self.directory} does not exist.")
 
         self._mdc = MixteraDataCollection(self.directory)
-        self._training_query_map_lock = threading.Lock()
+        self._training_query_map_lock = mp.Lock()
         self._training_query_map: dict[str, tuple[Query, int]] = {}  # (query, chunk_size)
 
     def register_dataset(


### PR DESCRIPTION
On macOS, the multiprocessing context is `spawn` instead of `fork`. In the spawn context, we cannot pickle a threading.Lock. Hence, we use a mp.Lock instead. While this is a bit more expensive, it's not on the hot path (only on query registration), and hence should be ok. This allows us to run the examples on macOS again.

Actually, I am not sure whether and why this worked before I left.