### PR TITLE
Fix the query result pickling to work on more platforms

### DIFF
--- a/mixtera/core/query/query_result.py
+++ b/mixtera/core/query/query_result.py
@@ -45,9 +45,9 @@ class QueryResult:
         self._lock = mp.Lock()
         self._index = mp.Value("i", 0)
 
-        # Prime the generator
-        self._generator: Generator[ChunkerIndex, tuple[Mixture, int], None] = self._chunk_generator()
-        next(self._generator)
+        #  The generator will be created lazily when calling __next__
+        self._generator: Generator[ChunkerIndex, tuple[Mixture, int], None] | None = None
+        self._num_returns_gen = 0
 
     def _parse_meta(self, mdc: MixteraDataCollection) -> dict:
         dataset_ids = set()
@@ -335,21 +335,38 @@ class QueryResult:
             self._index.get_obj().value += 1
 
         with self._lock:
+            #  The generator is created lazily since the QueryResult object might be pickled
+            # (and the generator was deleted from the state)
+            if self._generator is None:
+                self._generator = self._chunk_generator()
+                next(self._generator)
+
+                assert (
+                    self._num_returns_gen == 0
+                ), f"Generator was not reset properly. Got {self._num_returns_gen} returns."
+
+            self._num_returns_gen += 1
             return self._generator.send((self._mixture, chunk_target_index))
 
     def __getstate__(self) -> dict:
-        # _meta is not pickable using the default pickler (used by torch),
-        # so we have to rely on dill here
         state = self.__dict__.copy()
-        meta_pickled = dill.dumps(state["_meta"])
-        del state["_meta"]
-        # Also, we cannot pickle the manager, but also don't need it in the subclasses.
-        if "_manager" in state:
-            del state["_manager"]
+
+        # Remove the generator since it is not pickable (and will be recreated on __next__)
+        del state["_generator"]
+
+        #  The following attributes are pickled using dill since they are not pickable by
+        # the default pickler (used by torch)
+        dill_pickled_attributes = {}
+        for attrib in ["_meta", "_chunker_index", "_inverted_index"]:
+            attrib_pickled = dill.dumps(state[attrib])
+            del state[attrib]
+            dill_pickled_attributes[attrib] = attrib_pickled
 
         # Return a dictionary with the pickled attribute and other picklable attributes
-        return {"other": state, "meta_pickled": meta_pickled}
+        return {"other": state, "dilled": dill_pickled_attributes}
 
     def __setstate__(self, state: dict) -> None:
         self.__dict__ = state["other"]
-        self._meta = dill.loads(state["meta_pickled"])
+        self._generator = None
+        for attrib, attrib_pickled in state["dilled"].items():
+            setattr(self, attrib, dill.loads(attrib_pickled))


### PR DESCRIPTION
Linux is using fork for creating new processes which does not require pickling the QueryResult while macOS is using spawn. This resulted in different behaviour of the CI pipeline (integrationtest of pyTorch dataset) on the two platforms. To make the behaviour more robust we had to change the pickling of QueryResult to on one hand do not pickle the generator and secondly pickle more of the state using dill.

Co-authored-by:
MaxiBoether <2116466+MaxiBoether@users.noreply.github.com>