### PR TITLE
Increase timeout on waiting for query execution

### DIFF
--- a/mixtera/network/connection/server_connection.py
+++ b/mixtera/network/connection/server_connection.py
@@ -147,7 +147,9 @@ class ServerConnection:
         # Announce query
         await write_pickeled_object(query, NUM_BYTES_FOR_SIZES, writer)
 
-        success = bool(await read_int(NUM_BYTES_FOR_IDENTIFIERS, reader))
+        # TODO(#92): Execution at server can take some time. THerefore, we have a long timeout here.
+        # However, it would be best to switch to a polling based model.
+        success = bool(await read_int(NUM_BYTES_FOR_IDENTIFIERS, reader, timeout=60 * 15))
         logger.debug(f"Got success = {success} from server.")
         return success
 

--- a/mixtera/tests/network/connection/test_server_connection.py
+++ b/mixtera/tests/network/connection/test_server_connection.py
@@ -131,7 +131,7 @@ class TestServerConnection(unittest.IsolatedAsyncioTestCase):
         mock_write_pickeled_object.assert_any_await(mixture_mock, NUM_BYTES_FOR_SIZES, mock_writer)
         mock_write_pickeled_object.assert_any_await(query_mock, NUM_BYTES_FOR_SIZES, mock_writer)
         self.assertEqual(mock_write_pickeled_object.await_count, 2)
-        mock_read_int.assert_awaited_once_with(NUM_BYTES_FOR_IDENTIFIERS, mock_reader)
+        mock_read_int.assert_awaited_once_with(NUM_BYTES_FOR_IDENTIFIERS, mock_reader, timeout=60 * 15)
 
     @patch("mixtera.network.connection.server_connection.ServerConnection._connect_to_server")
     @patch("mixtera.network.connection.server_connection.read_pickeled_object")


### PR DESCRIPTION
Before properly fixing #92, this hack is required to allow us to execute queries.