### PR TITLE
fix: Monkey patch `mp.Process.start` on clients

### DIFF
--- a/mixtera/core/query/result_chunk.py
+++ b/mixtera/core/query/result_chunk.py
@@ -388,7 +388,6 @@ class ResultChunk:
         total_processes = 0
         pickled_func_dict = dill.dumps(self._parsing_func_dict)
         start_as_daemon = True if mp.current_process().daemon else None
-        logger.info(f"start_as_daemon = {start_as_daemon}")
         for key, process_count in process_counts.items():
             processes[key] = []
 


### PR DESCRIPTION
So far, we've only monkey patched in the constructor. Now we also patch in the configure function, because the constructor is not called again when transferring the chunk over the network.