### PR TITLE
fix: Sanity check for small chunks

### DIFF
--- a/mixtera/core/query/result_chunk.py
+++ b/mixtera/core/query/result_chunk.py
@@ -161,6 +161,16 @@ class ResultChunk:
                 logger.debug("Mixture is not defined or empty but required. Infer mixture from the result index.")
             self._mixture = self._infer_mixture()
 
+        if self._mixture is not None:
+            if any(value == 0 for value in self._mixture.values()):
+                logger.warning(
+                    "Note that you have zero-valued keys in your mixture."
+                    + "This might be the result of choosing a chunk size "
+                    + "that is potentially too small for your data distribution."
+                )
+                logger.warning(f"This is the mixture:\n\n{self._mixture}\n\n")
+                self._mixture = {key: value for key, value in self._mixture.items() if value > 0}
+
         # If we have a mixture, ensure that the mixture supports the chunk
         if self._mixture is not None and (not self._mixture.keys() == self._result_index.keys()):
             raise RuntimeError(


### PR DESCRIPTION
For small chunks, some mixture keys might be 0 in the target mixture. This triggered a sanity check which should not have been triggered. Instead, we should warn the user.